### PR TITLE
Improve curl errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_size = 2
+indent_style = space

--- a/functions/yvm.fish
+++ b/functions/yvm.fish
@@ -233,8 +233,16 @@ function _yvm_ls
         read yarn_version <"$yvm_fish_data/version"
     end
 
+    set -l seen
+
     # https://github.com/jorgebucaran/fish-cookbook#how-do-i-read-from-a-file-in-fish
     while read -la release
+        # Some releases are listed twice
+        if contains $release $seen
+          continue
+        end
+        set -a seen $release
+
         set -l parts (string split " " $release)
         set -l release_version $parts[1]
         set -l is_installed 0


### PR DESCRIPTION
The redirection of _yvm_get_releases into a variable turned out to be a
problem. I don't know how to exit early from that, since I can't use
return in a pipeline and exit will also quit the shell. I also can't use
return in the (_yvm_get_releases || return 1) calls.

The workaround for now is to save the curl call in a temp file. Now I
can do the usual || return 1 pattern. I also replaced -s with
--no-progress-meter so users see curl errors.

The end result of this is that an error from curl will stop the program
and the error should be visible. Same for errors from the tr awk
pipeline.